### PR TITLE
Use Ruby Version 2.7.4 on rubyonrails Workflow

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Ruby 2.7
         uses: ruby/setup-ruby@v1 # https://github.com/ruby/setup-ruby
         with:
-          ruby-version: 2.7 # Not needed with a .ruby-version file
+          ruby-version: 2.7.4 # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically, any step doing bundle install (for the root Gemfile) or gem install bundler can be removed with bundler-cache: true
       - name: Set up Node
         uses: actions/setup-node@v1


### PR DESCRIPTION
Currently the [rubyonrails workflow](https://github.com/hpi-swt2-exercise/rails-intro-exercise/blob/main/.github/workflows/rubyonrails.yml) is failing every single time with the error:

> Error: The process '/opt/hostedtoolcache/Ruby/2.7.5/x64/bin/bundle' failed with exit code 18

I believe the reason for this is that after [this](https://github.com/ruby/setup-ruby/commit/cf1a6dd2d8563b59c7007e381836fd252ab2ac5b) commit has been merged into [setup-ruby](https://github.com/ruby/setup-ruby) a few hours ago, the workflow picks version `2.7.5` by default which is incompatible with the version specified in the `.ruby-version` (`2.7.4`), which is also installed by most students I believe